### PR TITLE
제출 버튼을 눌렀을 때 동작하는 thunk action을 만들고 적용하라

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-redux": "^7.2.8",
-        "redux": "^4.1.2"
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-redux": "^7.2.8",
-    "redux": "^4.1.2"
+    "redux": "^4.1.2",
+    "redux-thunk": "^2.4.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,16 @@ import Header from "./components/Header";
 import Main from './components/Main';
 
 import { CssBaseline } from "@mui/material";
+import { useAppSelector } from "./hooks";
 import Loading from "./components/Loading/Loading";
 
 export default function App() {
+  const { loading: { isLoading, message } } = useAppSelector((state) => state.app);
+
   return (
     <>
       <CssBaseline />
-      <Loading />
+      {isLoading && <Loading text={message} />}
       <Header />
       <Main />
     </>

--- a/src/components/Form.test.tsx
+++ b/src/components/Form.test.tsx
@@ -11,7 +11,10 @@ import configureStore, { MockStoreEnhanced } from 'redux-mock-store';
 
 import { initialState } from "../slices/slice";
 
-const mockStore = configureStore();
+import thunk from 'redux-thunk';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
 
 jest.mock('../api');
 jest.mock('react-redux');
@@ -25,7 +28,9 @@ describe('Form', () => {
 
   beforeEach(() => {
     store = mockStore(() => ({
-      ...initialState,
+      app: {
+        ...initialState,
+      },
     }));
 
     (useDispatch as jest.Mock)
@@ -68,12 +73,13 @@ describe('Form', () => {
 
     fireEvent.click(getByText('제출하기'));
 
-
     await waitFor(() => {
       const actions = store.getActions();
 
-      expect(actions[0].type).toBe('app/setTimeTable');
-      expect(actions[0].payload).toEqual(mockUserList.data.timeTable);
+      expect(actions[0].type).toBe('app/setLoadingState');
+      expect(actions[1].type).toBe('app/setTimeTable');
+      expect(actions[1].payload).toEqual(mockUserList.data.timeTable);
+      expect(actions[2].type).toBe('app/setLoadingState');
     })
   });
 });

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -2,9 +2,8 @@ import { ChangeEvent, FormEvent } from 'react';
 
 import { Paper, Box, TextField, Typography, Button } from "@mui/material"
 
-import { loadUserTimeTable } from '../api';
 import { useAppDispatch, useAppSelector } from '../hooks';
-import { setForm, setTimeTable } from '../slices/slice';
+import { setForm, submitForm } from '../slices/slice';
 
 const style = {
   paper: {
@@ -27,7 +26,7 @@ const style = {
 export default function Form() {
   const dispatch = useAppDispatch();
 
-  const { form } = useAppSelector((state) => state);
+  const { form } = useAppSelector((state) => state.app);
 
   const handleChange = ({ target: { name, value } }: ChangeEvent<HTMLInputElement>) => {
     dispatch(setForm({ name, value }));
@@ -35,11 +34,7 @@ export default function Form() {
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
-
-    // TODO: 입력값에 대한 validation 필요. submit 에 대한 thunk action을 만들어 내부에서 validation 하자.
-    const { timeTable } = await loadUserTimeTable(form);
-
-    dispatch(setTimeTable(timeTable));
+    dispatch(submitForm());
   }
 
   return (

--- a/src/components/Main.test.tsx
+++ b/src/components/Main.test.tsx
@@ -7,7 +7,11 @@ import { useSelector } from "react-redux";
 
 import { initialState } from "../slices/slice";
 
-const mockStore = configureStore();
+import thunk from 'redux-thunk';
+import { AppDispatch } from "../store";
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
 
 jest.mock('react-redux');
 
@@ -16,11 +20,13 @@ describe('Main', () => {
     <Main />,
   );
 
-  let store: MockStoreEnhanced<unknown>;
+  let store: MockStoreEnhanced<unknown, AppDispatch>;
 
   beforeEach(() => {
     store = mockStore(() => ({
-      ...initialState,
+      app: {
+        ...initialState,
+      },
     }));
 
     (useSelector as jest.Mock)

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -6,7 +6,7 @@ import Form from "./Form";
 import TimeTable from './TimeTable/TimeTable';
 
 export default function Main() {
-  const { timeTable } = useAppSelector((state) => state);
+  const { timeTable } = useAppSelector((state) => state.app);
 
   return (
     <Container component="main" maxWidth={false}>

--- a/src/slices/slice.ts
+++ b/src/slices/slice.ts
@@ -1,5 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { loadUserTimeTable } from "../api";
 import { User } from "../interfaces";
+import { AppThunk } from "../store";
 
 export interface AppState {
   form: {
@@ -10,6 +12,10 @@ export interface AppState {
   timeTable: {
     [x: string]: User[],
   }
+  loading: {
+    isLoading: boolean,
+    message: string;
+  };
 }
 
 export const initialState: AppState = {
@@ -19,6 +25,10 @@ export const initialState: AppState = {
     articleNumber: '',
   },
   timeTable: {},
+  loading: {
+    isLoading: false,
+    message: '',
+  },
 }
 
 export const { actions, reducer } = createSlice({
@@ -36,12 +46,37 @@ export const { actions, reducer } = createSlice({
       ...state,
       timeTable,
     }),
+    setLoadingState: (state, { payload }) => ({ ...state, loading: payload }),
   },
 })
 
 export const {
   setForm,
   setTimeTable,
+  setLoadingState,
 } = actions;
+
+export const submitForm = (): AppThunk => async (dispatch, getState) => {
+  const { app } = getState();
+  const { form } = app;
+
+  dispatch(setLoadingState({
+    isLoading: true,
+    message: '데이터를 불러오고 있습니다...',
+  }));
+
+  try {
+    const { timeTable } = await loadUserTimeTable(form);
+    dispatch(setTimeTable(timeTable));
+  } catch (err) {
+    // TODO: Error 처리를 해야 함.
+    console.error(err);
+  } finally {
+    dispatch(setLoadingState({
+      isLoading: false,
+      message: '',
+    }));
+  }
+}
 
 export default reducer;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,10 +1,21 @@
-import { configureStore } from "@reduxjs/toolkit";
+import {
+  configureStore,
+  ThunkAction,
+} from "@reduxjs/toolkit";
 
-import reducer from './slices/slice';
+import { AnyAction, combineReducers } from "redux";
+
+import appReducer from './slices/slice';
+
+const reducer = combineReducers({
+  app: appReducer,
+})
 
 export const store = configureStore({
   reducer,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware({ thunk: true }),
 })
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch;
+export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, RootState, unknown, AnyAction>


### PR DESCRIPTION
예약 정보를 가져올 때 제출 버튼을 누르면 로딩 -> 데이터 가져옴 -> 로딩 끝 순서의 dispatch가 일어나도록 submit thunk action을 만들어 적용하였습니다.